### PR TITLE
update sponge-cli: fix ubuntu error of not enough permission to operate ~/.sponge when sponge init

### DIFF
--- a/cmd/sponge/commands/upgrade.go
+++ b/cmd/sponge/commands/upgrade.go
@@ -124,7 +124,7 @@ func copyToTempDir(targetVersion string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	err = executeCommand("chmod", "-R", "644", targetDir)
+	err = executeCommand("chmod", "-R", "744", targetDir)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
第一次使用的時候 sponge init 顯示錯誤  對 ~/.sponge 資料夾權限不足, 所以去看了一下 sponge-client 原始碼 修改了一下