### PR TITLE
Update go.mod API Change: `ToCamelCase` preserves source string case

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/consul/api v1.12.0
-	github.com/huandu/xstrings v1.3.3
+	github.com/huandu/xstrings v1.4.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/jinzhu/inflection v1.0.0
 	github.com/nacos-group/nacos-sdk-go/v2 v2.1.0


### PR DESCRIPTION
This is a breaking API change. The return value of ToCamelCase("toCamelCase") was Tocamelcase and then it's ToCamelCase now. If this change breaks your code, please let me know and open new issue against this change. Thanks.