### PR TITLE
20240723.add multipart

### DIFF
--- a/cmd/protoc-gen-go-gin/internal/generate/router/template.go
+++ b/cmd/protoc-gen-go-gin/internal/generate/router/template.go
@@ -123,11 +123,12 @@ type {{$.LowerName}}Router struct {
 func (r *{{$.LowerName}}Router) register() {
 {{range .Methods}}
 {{if eq .InvokeType 0}}
-		{{if eq .Method "FORM-DATA" }}
-		r.iRouter.Handle("POST", "{{.Path}}", r.withMiddleware("POST", "{{.Path}}", r.{{ .HandlerName }})...)
-		{{end}}
 		{{if .Path}}
-		r.iRouter.Handle("{{.Method}}", "{{.Path}}", r.withMiddleware("{{.Method}}", "{{.Path}}", r.{{ .HandlerName }})...)
+			{{if eq .Method "FORM-DATA" }}
+			r.iRouter.Handle("POST", "{{.Path}}", r.withMiddleware("POST", "{{.Path}}", r.{{ .HandlerName }})...)
+			{{else}}
+			r.iRouter.Handle("{{.Method}}", "{{.Path}}", r.withMiddleware("{{.Method}}", "{{.Path}}", r.{{ .HandlerName }})...)
+			{{end}}
 		{{end}}
 {{end}}
 {{end}}

--- a/cmd/protoc-gen-go-gin/internal/generate/router/template.go
+++ b/cmd/protoc-gen-go-gin/internal/generate/router/template.go
@@ -119,8 +119,17 @@ type {{$.LowerName}}Router struct {
 	wrapCtxFn             func(c *gin.Context) context.Context
 }
 
+
 func (r *{{$.LowerName}}Router) register() {
-{{range .Methods}}{{if eq .InvokeType 0}}{{if .Path}}r.iRouter.Handle("{{.Method}}", "{{.Path}}", r.withMiddleware("{{.Method}}", "{{.Path}}", r.{{ .HandlerName }})...){{end}}{{end}}
+{{range .Methods}}
+{{if eq .InvokeType 0}}
+		{{if eq .Method "FORM-DATA" }}
+		r.iRouter.Handle("POST", "{{.Path}}", r.withMiddleware("POST", "{{.Path}}", r.{{ .HandlerName }})...)
+		{{end}}
+		{{if .Path}}
+		r.iRouter.Handle("{{.Method}}", "{{.Path}}", r.withMiddleware("{{.Method}}", "{{.Path}}", r.{{ .HandlerName }})...)
+		{{end}}
+{{end}}
 {{end}}
 }
 
@@ -164,6 +173,15 @@ var _ middleware.CtxKeyString
 		return
 	}
 {{end}}
+
+{{if eq .Method "FORM-DATA" }}
+	if err = c.ShouldBindWith(req, binding.FormMultipart); err != nil {
+		r.zapLog.Warn("ShouldBindWith error", zap.Error(err), middleware.GCtxRequestIDField(c))
+		r.iResponse.ParamError(c, err)
+		return
+	}
+{{end}}
+
 {{if eq .Method "GET" "DELETE" }}
 	if err = c.ShouldBindQuery(req); err != nil {
 		r.zapLog.Warn("ShouldBindQuery error", zap.Error(err), middleware.GCtxRequestIDField(c))


### PR DESCRIPTION
support FORM-DATA method type in Gin router generation。
how to use in proto：
`  rpc Upload(UploadRequest) returns (UploadReply) {
    option (google.api.http) = {
      // CustomHttpPattern: "/v1/upload"
      custom:{
        kind:"FORM-DATA"
        path: "/v1/upload",
      }
      body: "*"
    };
  }`